### PR TITLE
Feature/search3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,8 @@
     "no-throw-literal": "off",
     "no-constructor-return": "off",
     "no-param-reassign": "off",
-    "no-plusplus": "off"
+    "no-plusplus": "off",
+    "no-unused-expressions": "off"
   },
   "env": {
     "browser": true,

--- a/src/pages/Search/SearchController.js
+++ b/src/pages/Search/SearchController.js
@@ -10,6 +10,11 @@ export default class SearchController {
     this.init();
   }
 
+  addHandlers() {
+    this.components.searchFormView.addHandler(this.handleSubmit);
+    this.components.recentKeywordListView.addHandler(this.handleDelete);
+  }
+
   // 화살표 함수로 만들어 인스턴스에 자동 binding 되도록 함.
   handleSubmit = e => {
     e.preventDefault();
@@ -21,7 +26,7 @@ export default class SearchController {
   controlRecentKeyword(keyword) {
     if (!keyword) return;
     this.model.setRecentKeywordList(keyword);
-    this.components.recentKeywordListView.show(this.model.recentKeywordList);
+    this.components.recentKeywordListView.render(this.model.recentKeywordList);
   }
 
   async controlSearchResult(keyword) {
@@ -30,6 +35,13 @@ export default class SearchController {
     searchResult && this.components.searchResultView.showResult(searchResult);
   }
 
+  handleDelete = e => {
+    if (e.target.className !== 'btn-delete') return;
+    const btnKey = e.target.dataset.key;
+    this.model.deleteKeyword(btnKey);
+    this.components.recentKeywordListView.render(this.model.recentKeywordList);
+  };
+
   init() {
     this.view.renderPage();
     this.components = {
@@ -37,6 +49,6 @@ export default class SearchController {
       recentKeywordListView: new RecentKeywordListView(),
       searchResultView: new SearchResultView(),
     };
-    this.components.searchFormView.addHandler(this.handleSubmit);
+    this.addHandlers();
   }
 }

--- a/src/pages/Search/SearchController.js
+++ b/src/pages/Search/SearchController.js
@@ -1,12 +1,19 @@
 /* eslint-disable no-unused-expressions */
-import { SearchFormView, RecentKeywordListView } from 'pages/Search';
-import SearchResultView from './views/components/SearchResultView';
+import {
+  SearchFormView,
+  RecentKeywordListView,
+  SearchResultView,
+} from 'pages/Search';
 
 export default class SearchController {
   constructor(model, view) {
     this.model = model;
     this.view = view;
     this.components = {};
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleDelete = this.handleDelete.bind(this);
+
     this.init();
   }
 
@@ -15,32 +22,31 @@ export default class SearchController {
     this.components.recentKeywordListView.addHandler(this.handleDelete);
   }
 
-  // 화살표 함수로 만들어 인스턴스에 자동 binding 되도록 함.
-  handleSubmit = e => {
+  handleSubmit(e) {
     e.preventDefault();
     const keyword = this.components.searchFormView.getKeyword().trim();
-    this.controlRecentKeyword(keyword);
-    this.controlSearchResult(keyword);
-  };
+    this.showRecentKeyword(keyword);
+    this.showSearchResult(keyword);
+  }
 
-  controlRecentKeyword(keyword) {
+  showRecentKeyword(keyword) {
     if (!keyword) return;
     this.model.setRecentKeywordList(keyword);
     this.components.recentKeywordListView.render(this.model.recentKeywordList);
   }
 
-  async controlSearchResult(keyword) {
+  async showSearchResult(keyword) {
     const searchResult = await this.model.searchGifs(keyword);
     this.components.searchResultView.showSearching();
     searchResult && this.components.searchResultView.showResult(searchResult);
   }
 
-  handleDelete = e => {
+  handleDelete(e) {
     if (e.target.className !== 'btn-delete') return;
     const btnKey = e.target.dataset.key;
     this.model.deleteKeyword(btnKey);
     this.components.recentKeywordListView.render(this.model.recentKeywordList);
-  };
+  }
 
   init() {
     this.view.renderPage();

--- a/src/pages/Search/SearchController.js
+++ b/src/pages/Search/SearchController.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-unused-expressions */
+import { SearchFormView, RecentKeywordListView } from 'pages/Search';
+import SearchResultView from './views/components/SearchResultView';
+
+export default class SearchController {
+  constructor(model, view) {
+    this.model = model;
+    this.view = view;
+    this.components = {};
+    this.init();
+  }
+
+  // 화살표 함수로 만들어 인스턴스에 자동 binding 되도록 함.
+  handleSubmit = e => {
+    e.preventDefault();
+    const keyword = this.components.searchFormView.getKeyword().trim();
+    this.controlRecentKeyword(keyword);
+    this.controlSearchResult(keyword);
+  };
+
+  controlRecentKeyword(keyword) {
+    if (!keyword) return;
+    this.model.setRecentKeywordList(keyword);
+    this.components.recentKeywordListView.show(this.model.recentKeywordList);
+  }
+
+  async controlSearchResult(keyword) {
+    const searchResult = await this.model.searchGifs(keyword);
+    this.components.searchResultView.showSearching();
+    searchResult && this.components.searchResultView.showResult(searchResult);
+  }
+
+  init() {
+    this.view.renderPage();
+    this.components = {
+      searchFormView: new SearchFormView(),
+      recentKeywordListView: new RecentKeywordListView(),
+      searchResultView: new SearchResultView(),
+    };
+    this.components.searchFormView.addHandler(this.handleSubmit);
+  }
+}

--- a/src/pages/Search/SearchModel.js
+++ b/src/pages/Search/SearchModel.js
@@ -7,7 +7,19 @@ export default class SearchModel {
   }
 
   setRecentKeywordList(keyword) {
+    if (
+      this.recentKeywordList.length > 0 &&
+      this.recentKeywordList[0].keyword === keyword
+    )
+      return;
+
     const newItem = { keyword, key: makeRandomKey(5) };
+    const existingIndex = this.recentKeywordList.findIndex(
+      item => item.keyword === keyword
+    );
+    if (existingIndex >= 0) {
+      this.recentKeywordList.splice(existingIndex, 1);
+    }
     this.recentKeywordList.unshift(newItem);
   }
 

--- a/src/pages/Search/SearchModel.js
+++ b/src/pages/Search/SearchModel.js
@@ -7,11 +7,7 @@ export default class SearchModel {
   }
 
   setRecentKeywordList(keyword) {
-    if (
-      this.recentKeywordList.length > 0 &&
-      this.recentKeywordList[0].keyword === keyword
-    )
-      return;
+    if (this.recentKeywordList[0]?.keyword === keyword) return;
 
     const newItem = { keyword, key: makeRandomKey(5) };
     const existingIndex = this.recentKeywordList.findIndex(
@@ -23,18 +19,24 @@ export default class SearchModel {
     this.recentKeywordList.unshift(newItem);
   }
 
-  async searchGifs(keyword) {
-    const { data } = await axiosClient.get('/search', {
-      params: {
-        q: keyword,
-        tag: 'hello',
-        rating: 'g',
-        lang: 'ko',
-        limit: 25,
-      },
-    });
+  async fetchSearch(keyword) {
+    return axiosClient
+      .get('/search', {
+        params: {
+          q: keyword,
+          tag: 'hello',
+          rating: 'g',
+          lang: 'ko',
+          limit: 25,
+        },
+      })
+      .then(res => res.data);
+  }
 
-    const searchResult = data.data.map(({ id, images }) => ({
+  async searchGifs(keyword) {
+    const { data } = await this.fetchSearch(keyword);
+
+    const searchResult = data.map(({ id, images }) => ({
       id,
       gifUrl: images.fixed_width.url,
     }));

--- a/src/pages/Search/SearchModel.js
+++ b/src/pages/Search/SearchModel.js
@@ -1,0 +1,34 @@
+import axiosClient from 'libs/axios';
+import makeRandomKey from 'utils/makeRandomKey';
+
+export default class SearchModel {
+  constructor() {
+    this.recentKeywordList = [];
+  }
+
+  setRecentKeywordList(keyword) {
+    const newItem = { keyword, key: makeRandomKey(5) };
+    this.recentKeywordList.unshift(newItem);
+  }
+
+  async searchGifs(keyword) {
+    const { data } = await axiosClient.get('/search', {
+      params: {
+        q: keyword,
+        tag: 'hello',
+        rating: 'g',
+        lang: 'ko',
+        limit: 25,
+      },
+    });
+
+    console.log(data.data);
+
+    const searchResult = data.data.map(({ id, images }) => ({
+      id,
+      gifUrl: images.fixed_width.url,
+    }));
+
+    return searchResult;
+  }
+}

--- a/src/pages/Search/SearchModel.js
+++ b/src/pages/Search/SearchModel.js
@@ -22,13 +22,17 @@ export default class SearchModel {
       },
     });
 
-    console.log(data.data);
-
     const searchResult = data.data.map(({ id, images }) => ({
       id,
       gifUrl: images.fixed_width.url,
     }));
 
     return searchResult;
+  }
+
+  deleteKeyword(key) {
+    this.recentKeywordList = this.recentKeywordList.filter(
+      item => item.key !== key
+    );
   }
 }

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -3,6 +3,7 @@ import SearchModel from './SearchModel';
 import SearchView from './views/SearchView';
 import SearchFormView from './views/components/SearchFormView';
 import RecentKeywordListView from './views/components/RecentKeywordListView';
+import SearchResultView from './views/components/SearchResultView';
 
 export {
   SearchController,
@@ -10,4 +11,5 @@ export {
   SearchView,
   SearchFormView,
   RecentKeywordListView,
+  SearchResultView,
 };

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -1,0 +1,13 @@
+import SearchController from './SearchController';
+import SearchModel from './SearchModel';
+import SearchView from './views/SearchView';
+import SearchFormView from './views/components/SearchFormView';
+import RecentKeywordListView from './views/components/RecentKeywordListView';
+
+export {
+  SearchController,
+  SearchModel,
+  SearchView,
+  SearchFormView,
+  RecentKeywordListView,
+};

--- a/src/pages/Search/views/SearchView.js
+++ b/src/pages/Search/views/SearchView.js
@@ -1,0 +1,13 @@
+import View from 'pages/View';
+import template from './template';
+import './searchView.scss';
+
+export default class SearchView extends View {
+  constructor() {
+    super(document.querySelector('main'));
+  }
+
+  renderPage() {
+    super.render(template());
+  }
+}

--- a/src/pages/Search/views/components/RecentKeywordListView.js
+++ b/src/pages/Search/views/components/RecentKeywordListView.js
@@ -1,0 +1,12 @@
+import View from 'src/pages/View';
+import { keywordListTemplate } from '../template';
+
+export default class RecentKeywordListView extends View {
+  constructor() {
+    super(document.querySelector('.recent-keyword-list-wrap'));
+  }
+
+  show(keywordList) {
+    super.render(keywordListTemplate(keywordList));
+  }
+}

--- a/src/pages/Search/views/components/RecentKeywordListView.js
+++ b/src/pages/Search/views/components/RecentKeywordListView.js
@@ -6,7 +6,12 @@ export default class RecentKeywordListView extends View {
     super(document.querySelector('.recent-keyword-list-wrap'));
   }
 
-  show(keywordList) {
+  render(keywordList) {
+    keywordList.length > 0 ? super.show('flex') : super.hide();
     super.render(keywordListTemplate(keywordList));
+  }
+
+  addHandler(handler) {
+    this.element.addEventListener('click', e => handler(e));
   }
 }

--- a/src/pages/Search/views/components/SearchFormView.js
+++ b/src/pages/Search/views/components/SearchFormView.js
@@ -1,0 +1,15 @@
+import View from 'src/pages/View';
+
+export default class SearchFormView extends View {
+  constructor() {
+    super(document.querySelector('.search-form-view'));
+  }
+
+  getKeyword() {
+    return this.element.querySelector('input').value;
+  }
+
+  addHandler(handler) {
+    this.element.addEventListener('submit', e => handler(e));
+  }
+}

--- a/src/pages/Search/views/components/SearchResultView.js
+++ b/src/pages/Search/views/components/SearchResultView.js
@@ -1,0 +1,24 @@
+import View from 'src/pages/View';
+import {
+  searchingTemplate,
+  searchResultTemplate,
+  emptyTemplate,
+} from '../template';
+
+export default class SearchResultView extends View {
+  constructor() {
+    super(document.querySelector('.gif-list-wrapper'));
+  }
+
+  showResult(searchResult) {
+    if (searchResult.length < 1) {
+      super.render(emptyTemplate());
+      return;
+    }
+    super.render(searchResultTemplate(searchResult));
+  }
+
+  showSearching() {
+    super.render(searchingTemplate());
+  }
+}

--- a/src/pages/Search/views/components/SearchResultView.js
+++ b/src/pages/Search/views/components/SearchResultView.js
@@ -11,11 +11,11 @@ export default class SearchResultView extends View {
   }
 
   showResult(searchResult) {
-    if (searchResult.length < 1) {
-      super.render(emptyTemplate());
-      return;
-    }
-    super.render(searchResultTemplate(searchResult));
+    super.render(
+      searchResult.length > 0
+        ? searchResultTemplate(searchResult)
+        : emptyTemplate()
+    );
   }
 
   showSearching() {

--- a/src/pages/Search/views/searchView.scss
+++ b/src/pages/Search/views/searchView.scss
@@ -1,0 +1,126 @@
+@import 'styles/variables.scss';
+
+#search-view-wrapper {
+  min-height: 100vh;
+  background-color: $color-violet;
+  text-align: center;
+  margin: 0 auto;
+  padding-bottom: 200px;
+
+  form {
+    margin: 0 auto;
+    width: 600px;
+    padding: 40px 0 10px;
+    display: flex;
+    align-items: center;
+    font-size: $font-xl-regular;
+  }
+
+  input {
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid black;
+    box-sizing: border-box;
+    width: 100%;
+    margin: 15px 0 15px 0;
+    padding: 10px 15px;
+    line-height: 1.5;
+    font-size: $font-xl-regular;
+
+    &::placeholder {
+      color: $color-dark-gray;
+      font-size: $font-xl-regular;
+    }
+  }
+
+  button {
+    font-size: $font-xl-regular;
+    color: $color-violet;
+    cursor: pointer;
+
+    &.btn-reset {
+      position: relative;
+      right: 25px;
+      border: none;
+      border-radius: 50%;
+      font-size: $font-regular;
+      background-color: $color-dark-gray;
+    }
+
+    &.btn-submit {
+      position: relative;
+      width: 130px;
+      padding: 15px 0;
+      border: none;
+      background-color: $color-black;
+      color: white;
+    }
+  }
+
+  .recent-keyword-list-wrap {
+    width: 800px;
+    margin: 0 auto 40px;
+    display: flex;
+    align-items: center;
+
+    .title {
+      white-space: no-wrap;
+      width: 180px;
+      font-size: $font-regular;
+      font-weight: bold;
+      margin-right: 10px;
+    }
+
+    ul {
+      overflow: auto;
+      white-space: nowrap;
+      overflow-x: scroll;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+
+      li {
+        display: inline-block;
+        background-color: $color-black;
+        border-radius: 30px;
+        color: white;
+        text-align: center;
+        padding: 10px;
+        margin-right: 10px;
+        text-decoration: none;
+
+        .btn-delete {
+          margin-left: 4px;
+          border: none;
+          border-radius: 50%;
+          font-size: $font-small;
+          background-color: $color-dark-gray;
+          width: 20px;
+          height: 20px;
+          color: $color-gray;
+        }
+      }
+    }
+  }
+  .gif-list-wrapper {
+    padding: 0 100px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+
+    .gif-wrapper {
+      // flex-basis: auto;
+      width: 200px;
+      height: 200px;
+      margin: 10px;
+      object-fit: cover;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    }
+  }
+}

--- a/src/pages/Search/views/searchView.scss
+++ b/src/pages/Search/views/searchView.scss
@@ -110,11 +110,24 @@
     justify-content: center;
 
     .gif-wrapper {
-      // flex-basis: auto;
+      position: relative;
       width: 200px;
       height: 200px;
       margin: 10px;
       object-fit: cover;
+      cursor: pointer;
+
+      .layer {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background-color: black;
+        opacity: 0;
+
+        &:hover {
+          opacity: 0.4;
+        }
+      }
 
       img {
         width: 100%;

--- a/src/pages/Search/views/template.js
+++ b/src/pages/Search/views/template.js
@@ -1,0 +1,49 @@
+const template = () => {
+  return `
+        <div id="search-view-wrapper">
+            <form class="search-form-view">
+                <input type="text" placeholder="검색어를 입력하세요" autofocus />
+                <button type="reset" class="btn-reset">X</button>
+                <button type="submit" class="btn-submit">확인</button>
+            </form>
+            <div class="recent-keyword-list-wrap"></div>
+            <div class="gif-list-wrapper"></div>
+      `;
+};
+
+export const keywordListTemplate = keywordList => {
+  return `
+  <span class="title">최근검색어</span>
+  <ul class="list-wrapper">
+    ${keywordList
+      .map(
+        ({ keyword, key }) => `
+      <li>${keyword}<button class="btn-delete" data-key=${key}>x</button></li>
+    `
+      )
+      .join('')}
+  </ul>
+    `;
+};
+
+export const searchingTemplate = () => {
+  return `<div class="searching">검색중...</div>`;
+};
+
+export const emptyTemplate = () => {
+  return `<div class="searching">검색 결과가 없습니다.</div>`;
+};
+
+export const searchResultTemplate = searchedGifList => {
+  return searchedGifList
+    .map(
+      ({ id, gifUrl }) =>
+        `
+      <div class="gif-wrapper" data-id=${id}>
+      <img src=${gifUrl} alt="giphy"  />
+      </div>`
+    )
+    .join('');
+};
+
+export default template;

--- a/src/pages/Search/views/template.js
+++ b/src/pages/Search/views/template.js
@@ -40,6 +40,7 @@ export const searchResultTemplate = searchedGifList => {
       ({ id, gifUrl }) =>
         `
       <div class="gif-wrapper" data-id=${id}>
+      <div class="layer"></div>
       <img src=${gifUrl} alt="giphy"  />
       </div>`
     )

--- a/src/pages/View.js
+++ b/src/pages/View.js
@@ -15,8 +15,8 @@ export default class View {
     return this;
   }
 
-  show(target = this.element) {
-    target.style.display = 'visible';
+  show(value = 'block') {
+    this.element.style.display = value;
     return this;
   }
 }

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -9,7 +9,6 @@ body {
   width: 100vw;
   overflow-x: hidden;
   color: $color-black;
-
 }
 
 input:focus {

--- a/src/utils/makeRandomKey.js
+++ b/src/utils/makeRandomKey.js
@@ -1,0 +1,12 @@
+const makeRandomKey = length => {
+  let randomKey = '';
+  const characters = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOP';
+  for (let i = 0; i < length; i++) {
+    randomKey += characters.charAt(
+      Math.floor(Math.random() * characters.length)
+    );
+  }
+  return randomKey;
+};
+
+export default makeRandomKey;


### PR DESCRIPTION
## PR Type

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 : )

## 작업 내용
- Search 화면 MVC 구현

## 예상되는 결과
- 검색 창에 검색어를 입력하고 확인버튼 or enter를 누르면 최근검색어에 검색어가 저장되고, 검색 결과가 화면에 나온다.
- 최근 검색어를 삭제할 수 있으며 모두 삭제시 아예 해당 영역이 사라진다.
- 최근 검색어에 방금 검색한 단어 있을시 가장 앞에 보여준다.

## 리뷰어가 중점적으로 봤으면 하는 부분
- 각각의 컴포넌트들이 main안에 있는 template에서 요소를 잡아서 뷰를 그리고 있기 때문에 router에서는 페이지의 구조가 되는 SearchView만 컨트롤러에 넘겨주고, init시에 나머지 뷰들을 묶어서 `this.component`로 주입하고 있는데, 더 좋은 방법이 있는지 궁금합니다. 현재 구조에서는 재사용이 어려워 다른 방법으로 뷰를 주입하도록 리팩토링 진행 예정입니다..

- MVC 모델에 맞게 잘 구현이 되었는지 궁금합니다.

## 예시 화면

https://user-images.githubusercontent.com/90900882/232327404-12447da3-b812-4b3d-909f-e8b4dc79062f.mp4

